### PR TITLE
Fix the superclass of Fluent::DeparserFilter

### DIFF
--- a/lib/fluent/plugin/filter_deparser.rb
+++ b/lib/fluent/plugin/filter_deparser.rb
@@ -1,4 +1,4 @@
-class Fluent::DeparserFilter < Fluent::Output
+class Fluent::DeparserFilter < Fluent::Filter
   Fluent::Plugin.register_filter('deparser', self)
 
   config_param :format, :string


### PR DESCRIPTION
Fluent::DeparserFilter is the subclass of Fluent::Output.
It should be changed to Fluent::Filter.

This is for #26.

Sorry for no testcase. I have no idea to test this.
